### PR TITLE
Fix missing dist files for CDN usage

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -3,5 +3,4 @@
 /lib/provider/template.js
 .*
 coverage
-dist
 *.test.js

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.2.6",
   "description": "A parser to extract provider, video id, starttime and others from YouTube, Vimeo, ... urls",
   "main": "lib/index.js",
+  "files": ["dist"],
   "repository": {
     "type": "git",
     "url": "https://github.com/Zod-/jsVideoUrlParser.git"

--- a/package.json
+++ b/package.json
@@ -3,7 +3,6 @@
   "version": "0.2.6",
   "description": "A parser to extract provider, video id, starttime and others from YouTube, Vimeo, ... urls",
   "main": "lib/index.js",
-  "files": ["dist"],
   "repository": {
     "type": "git",
     "url": "https://github.com/Zod-/jsVideoUrlParser.git"


### PR DESCRIPTION
Hi, thank you for this fine package.

It seems version 0.2.5 removed the `dist` folder from NPM. This means you can no longer use services such as https://unpkg.com with this package. For instance:

- https://unpkg.com/js-video-url-parser@0.2.5/dist/jsVideoUrlParser.min.js (404)
- https://unpkg.com/js-video-url-parser@0.2.4/dist/jsVideoUrlParser.min.js (all good)

One way to fix this, is to add the `dist` folder to the `files` array in package.json to ensure it's included. There is a bit about "Workflow" at the bottom of this page https://unpkg.com/