### PR TITLE
Add support for YouTube channel URLs

### DIFF
--- a/lib/provider/youtube.js
+++ b/lib/provider/youtube.js
@@ -30,16 +30,32 @@ function YouTube() {
     VIDEO: 'video',
     PLAYLIST: 'playlist',
     SHARE: 'share',
+    CHANNEL: 'channel',
   };
 }
 
 module.exports = YouTube;
 
-YouTube.prototype.parseUrl = function(url) {
+YouTube.prototype.parseVideoUrl = function(url) {
   var match = url.match(
     /(?:(?:v|vi|be|videos|embed)\/(?!videoseries)|(?:v|ci)=)([\w-]{11})/i
   );
   return match ? match[1] : undefined;
+};
+
+YouTube.prototype.parseChannelUrl = function(url) {
+  // Match an opaque channel ID
+  var match = url.match(/\/channel\/([\w-]+)/);
+  if (match) {
+    return { id: match[1], mediaType: this.mediaTypes.CHANNEL };
+  }
+
+  // Match a vanity channel name or a user name. User urls are deprecated and
+  // currently redirect to the channel of that same name.
+  match = (url.match(/\/c\/([\w-]+)/) || url.match(/\/user\/([\w-]+)/));
+  if (match) {
+    return { name: match[1], mediaType: this.mediaTypes.CHANNEL };
+  }
 };
 
 YouTube.prototype.parseParameters = function(params, result) {
@@ -77,13 +93,18 @@ YouTube.prototype.parseMediaType = function(result) {
 };
 
 YouTube.prototype.parse = function(url, params) {
-  var result = {
-    params: params,
-    id: this.parseUrl(url),
-  };
-  result.params = this.parseParameters(params, result);
-  result = this.parseMediaType(result);
-  return result;
+  var channelResult = this.parseChannelUrl(url);
+  if (channelResult) {
+    return channelResult;
+  } else {
+    var result = {
+      params: params,
+      id: this.parseVideoUrl(url),
+    };
+    result.params = this.parseParameters(params, result);
+    result = this.parseMediaType(result);
+    return result;
+  }
 };
 
 YouTube.prototype.createShortUrl = function(vi, params) {
@@ -99,6 +120,13 @@ YouTube.prototype.createLongUrl = function(vi, params) {
   var startTime = params.start;
   delete params.start;
 
+  if (vi.mediaType === this.mediaTypes.CHANNEL) {
+    if (vi.id) {
+      url += 'https://www.youtube.com/channel/' + vi.id;
+    } else if (vi.name) {
+      url += 'https://www.youtube.com/c/' + vi.name;
+    }
+  }
   if (vi.mediaType === this.mediaTypes.PLAYLIST) {
     params.feature = 'share';
     url += 'https://youtube.com/playlist';

--- a/lib/provider/youtube.test.js
+++ b/lib/provider/youtube.test.js
@@ -251,3 +251,32 @@ test('YouTube: share urls', () => {
     urls: ['https://www.youtube.com/shared?ci=E14kBrDEvYo'],
   });
 });
+
+test('YouTube: channel urls', () => {
+  testUrls(newParser(), {
+    videoInfo: {
+      provider: 'youtube',
+      id: 'UCzQUP1qoWDoEbmsQxvdjxgQ',
+      mediaType: 'channel',
+    },
+    formats: {
+      long: 'https://www.youtube.com/channel/UCzQUP1qoWDoEbmsQxvdjxgQ',
+    },
+    urls: ['https://www.youtube.com/channel/UCzQUP1qoWDoEbmsQxvdjxgQ'],
+  });
+
+  testUrls(newParser(), {
+    videoInfo: {
+      provider: 'youtube',
+      name: 'PowerfulJRE',
+      mediaType: 'channel',
+    },
+    formats: {
+      long: 'https://www.youtube.com/c/PowerfulJRE',
+    },
+    urls: [
+      'https://www.youtube.com/user/PowerfulJRE',
+      'https://www.youtube.com/c/PowerfulJRE',
+    ],
+  });
+});


### PR DESCRIPTION
This parses channel URLs that look like:
  https://www.youtube.com/channel/UCzQUP1qoWDoEbmsQxvdjxgQ
  https://www.youtube.com/c/PowerfulJRE
  https://www.youtube.com/user/PowerfulJRE

into objects that look like:
`{
  mediaType: "channel",
  id: "UCzQUP1qoWDoEbmsQxvdjxgQ",
  provider: "youtube"
}`

Or:

`{
  mediaType: "channel",
  name: "PowerfulJRE",
  provider: "youtube"
}`