### PR TITLE
Updates createEmbedUrl for YouTube to include https://www.

### DIFF
--- a/lib/provider/youtube.js
+++ b/lib/provider/youtube.js
@@ -155,7 +155,7 @@ YouTube.prototype.createLongUrl = function(vi, params) {
 };
 
 YouTube.prototype.createEmbedUrl = function(vi, params) {
-  var url = '//youtube.com/embed';
+  var url = 'https://www.youtube.com/embed';
 
   if (vi.mediaType === this.mediaTypes.PLAYLIST) {
     params.listType = 'playlist';

--- a/lib/provider/youtube.test.js
+++ b/lib/provider/youtube.test.js
@@ -24,7 +24,7 @@ test('YouTube: regular urls', () => {
     },
     formats: {
       long: 'https://youtube.com/watch?v=HRb7B9fPhfA',
-      embed: '//youtube.com/embed/HRb7B9fPhfA',
+      embed: 'https://www.youtube.com/embed/HRb7B9fPhfA',
       short: 'https://youtu.be/HRb7B9fPhfA',
       shortImage: 'https://i.ytimg.com/vi/HRb7B9fPhfA/hqdefault.jpg',
       longImage: 'https://img.youtube.com/vi/HRb7B9fPhfA/hqdefault.jpg',
@@ -46,7 +46,7 @@ test('YouTube: regular urls', () => {
     },
     formats: {
       long: 'https://youtube.com/watch?v=HRb7B9fPhfA#t=30',
-      embed: '//youtube.com/embed/HRb7B9fPhfA?start=30',
+      embed: 'https://www.youtube.com/embed/HRb7B9fPhfA?start=30',
       short: 'https://youtu.be/HRb7B9fPhfA#t=30',
     },
     urls: [
@@ -55,7 +55,7 @@ test('YouTube: regular urls', () => {
       'https://m.youtube.com/details?v=HRb7B9fPhfA#t=30s',
       'http://youtu.be/HRb7B9fPhfA?t=30s',
       'http://youtu.be/HRb7B9fPhfA#t=30s',
-      '//youtube.com/embed/HRb7B9fPhfA?start=30',
+      'https://www.youtube.com/embed/HRb7B9fPhfA?start=30',
     ],
   });
   testUrls(newParser(), {
@@ -69,9 +69,9 @@ test('YouTube: regular urls', () => {
       },
     },
     formats: {
-      embed: '//youtube.com/embed/HRb7B9fPhfA?loop=1&playlist=HRb7B9fPhfA&start=30',
+      embed: 'https://www.youtube.com/embed/HRb7B9fPhfA?loop=1&playlist=HRb7B9fPhfA&start=30',
     },
-    urls: ['//youtube.com/embed/HRb7B9fPhfA?loop=1&list=HRb7B9fPhfA&start=30'],
+    urls: ['https://www.youtube.com/embed/HRb7B9fPhfA?loop=1&list=HRb7B9fPhfA&start=30'],
   });
 });
 
@@ -88,12 +88,12 @@ test('YouTube: playlist urls', () => {
     },
     formats: {
       long: 'https://youtube.com/watch?list=PL46F0A159EC02DF82&v=yQaAGmHNn9s#t=100',
-      embed: '//youtube.com/embed/yQaAGmHNn9s?list=PL46F0A159EC02DF82&start=100',
+      embed: 'https://www.youtube.com/embed/yQaAGmHNn9s?list=PL46F0A159EC02DF82&start=100',
     },
     urls: [
       'http://www.youtube.com/watch?v=yQaAGmHNn9s&list=PL46F0A159EC02DF82#t=1m40',
       'http://www.youtube.com/watch?v=yQaAGmHNn9s&list=PL46F0A159EC02DF82&t=1m40',
-      '//youtube.com/embed/yQaAGmHNn9s?list=PL46F0A159EC02DF82&start=100',
+      'https://www.youtube.com/embed/yQaAGmHNn9s?list=PL46F0A159EC02DF82&start=100',
     ],
   });
   testUrls(newParser(), {
@@ -105,11 +105,11 @@ test('YouTube: playlist urls', () => {
     },
     formats: {
       long: 'https://youtube.com/watch?list=PL46F0A159EC02DF82&v=yQaAGmHNn9s',
-      embed: '//youtube.com/embed/yQaAGmHNn9s?list=PL46F0A159EC02DF82',
+      embed: 'https://www.youtube.com/embed/yQaAGmHNn9s?list=PL46F0A159EC02DF82',
     },
     urls: [
       'http://www.youtube.com/watch?v=yQaAGmHNn9s&list=PL46F0A159EC02DF82',
-      '//youtube.com/embed/yQaAGmHNn9s?list=PL46F0A159EC02DF82',
+      'https://www.youtube.com/embed/yQaAGmHNn9s?list=PL46F0A159EC02DF82',
     ],
   });
   testUrls(newParser(), {
@@ -124,12 +124,12 @@ test('YouTube: playlist urls', () => {
     },
     formats: {
       long: 'https://youtube.com/watch?index=25&list=PL46F0A159EC02DF82&v=6xLcSTDeB7A',
-      embed: '//youtube.com/embed/6xLcSTDeB7A?index=25&list=PL46F0A159EC02DF82',
+      embed: 'https://www.youtube.com/embed/6xLcSTDeB7A?index=25&list=PL46F0A159EC02DF82',
     },
     urls: [
       'https://www.youtube.com/watch?v=6xLcSTDeB7A&list=PL46F0A159EC02DF82&index=25',
       'https://www.youtube.com/watch?v=6xLcSTDeB7A&index=25&list=PL46F0A159EC02DF82',
-      '//youtube.com/embed/6xLcSTDeB7A?index=25&list=PL46F0A159EC02DF82',
+      'https://www.youtube.com/embed/6xLcSTDeB7A?index=25&list=PL46F0A159EC02DF82',
     ],
   });
   testUrls(newParser(), {
@@ -145,14 +145,14 @@ test('YouTube: playlist urls', () => {
     },
     formats: {
       long: 'https://youtube.com/watch?index=25&list=PL46F0A159EC02DF82&v=6xLcSTDeB7A#t=100',
-      embed: '//youtube.com/embed/6xLcSTDeB7A?index=25&list=PL46F0A159EC02DF82&start=100',
+      embed: 'https://www.youtube.com/embed/6xLcSTDeB7A?index=25&list=PL46F0A159EC02DF82&start=100',
     },
     urls: [
       'https://www.youtube.com/watch?v=6xLcSTDeB7A&list=PL46F0A159EC02DF82&index=25#t=1m40',
       'https://www.youtube.com/watch?v=6xLcSTDeB7A&list=PL46F0A159EC02DF82&index=25&t=1m40',
       'https://www.youtube.com/watch?v=6xLcSTDeB7A&index=25&list=PL46F0A159EC02DF82&t=1m40',
       'https://www.youtube.com/watch?v=6xLcSTDeB7A&index=25&list=PL46F0A159EC02DF82#t=1m40',
-      '//youtube.com/embed/6xLcSTDeB7A?index=25&list=PL46F0A159EC02DF82&start=100',
+      'https://www.youtube.com/embed/6xLcSTDeB7A?index=25&list=PL46F0A159EC02DF82&start=100',
     ],
   });
   testUrls(newParser(), {
@@ -163,7 +163,7 @@ test('YouTube: playlist urls', () => {
     },
     formats: {
       long: 'https://youtube.com/playlist?feature=share&list=PL46F0A159EC02DF82',
-      embed: '//youtube.com/embed?list=PL46F0A159EC02DF82&listType=playlist',
+      embed: 'https://www.youtube.com/embed?list=PL46F0A159EC02DF82&listType=playlist',
     },
     urls: [
       'http://www.youtube.com/embed/videoseries?list=PL46F0A159EC02DF82',
@@ -180,9 +180,9 @@ test('YouTube: playlist urls', () => {
       },
     },
     formats: {
-      embed: '//youtube.com/embed?list=PL46F0A159EC02DF82&listType=playlist',
+      embed: 'https://www.youtube.com/embed?list=PL46F0A159EC02DF82&listType=playlist',
     },
-    urls: ['//youtube.com/embed?list=PL46F0A159EC02DF82&listType=playlist'],
+    urls: ['https://www.youtube.com/embed?list=PL46F0A159EC02DF82&listType=playlist'],
   });
 });
 
@@ -196,7 +196,7 @@ test('YouTube: feed urls', () => {
     formats: {
       long: 'https://youtube.com/watch?v=HRb7B9fPhfA',
       short: 'https://youtu.be/HRb7B9fPhfA',
-      embed: '//youtube.com/embed/HRb7B9fPhfA',
+      embed: 'https://www.youtube.com/embed/HRb7B9fPhfA',
     },
     urls: [
       'https://gdata.youtube.com/feeds/api/videos/HRb7B9fPhfA/related',

--- a/lib/provider/youtube.test.js
+++ b/lib/provider/youtube.test.js
@@ -55,7 +55,7 @@ test('YouTube: regular urls', () => {
       'https://m.youtube.com/details?v=HRb7B9fPhfA#t=30s',
       'http://youtu.be/HRb7B9fPhfA?t=30s',
       'http://youtu.be/HRb7B9fPhfA#t=30s',
-      'https://www.youtube.com/embed/HRb7B9fPhfA?start=30',
+      '//youtube.com/embed/HRb7B9fPhfA?start=30',
     ],
   });
   testUrls(newParser(), {
@@ -71,7 +71,7 @@ test('YouTube: regular urls', () => {
     formats: {
       embed: 'https://www.youtube.com/embed/HRb7B9fPhfA?loop=1&playlist=HRb7B9fPhfA&start=30',
     },
-    urls: ['https://www.youtube.com/embed/HRb7B9fPhfA?loop=1&list=HRb7B9fPhfA&start=30'],
+    urls: ['//youtube.com/embed/HRb7B9fPhfA?loop=1&list=HRb7B9fPhfA&start=30'],
   });
 });
 
@@ -93,7 +93,7 @@ test('YouTube: playlist urls', () => {
     urls: [
       'http://www.youtube.com/watch?v=yQaAGmHNn9s&list=PL46F0A159EC02DF82#t=1m40',
       'http://www.youtube.com/watch?v=yQaAGmHNn9s&list=PL46F0A159EC02DF82&t=1m40',
-      'https://www.youtube.com/embed/yQaAGmHNn9s?list=PL46F0A159EC02DF82&start=100',
+      '//youtube.com/embed/yQaAGmHNn9s?list=PL46F0A159EC02DF82&start=100',
     ],
   });
   testUrls(newParser(), {
@@ -109,7 +109,7 @@ test('YouTube: playlist urls', () => {
     },
     urls: [
       'http://www.youtube.com/watch?v=yQaAGmHNn9s&list=PL46F0A159EC02DF82',
-      'https://www.youtube.com/embed/yQaAGmHNn9s?list=PL46F0A159EC02DF82',
+      '//youtube.com/embed/yQaAGmHNn9s?list=PL46F0A159EC02DF82',
     ],
   });
   testUrls(newParser(), {
@@ -129,7 +129,7 @@ test('YouTube: playlist urls', () => {
     urls: [
       'https://www.youtube.com/watch?v=6xLcSTDeB7A&list=PL46F0A159EC02DF82&index=25',
       'https://www.youtube.com/watch?v=6xLcSTDeB7A&index=25&list=PL46F0A159EC02DF82',
-      'https://www.youtube.com/embed/6xLcSTDeB7A?index=25&list=PL46F0A159EC02DF82',
+      '//youtube.com/embed/6xLcSTDeB7A?index=25&list=PL46F0A159EC02DF82',
     ],
   });
   testUrls(newParser(), {
@@ -152,7 +152,7 @@ test('YouTube: playlist urls', () => {
       'https://www.youtube.com/watch?v=6xLcSTDeB7A&list=PL46F0A159EC02DF82&index=25&t=1m40',
       'https://www.youtube.com/watch?v=6xLcSTDeB7A&index=25&list=PL46F0A159EC02DF82&t=1m40',
       'https://www.youtube.com/watch?v=6xLcSTDeB7A&index=25&list=PL46F0A159EC02DF82#t=1m40',
-      'https://www.youtube.com/embed/6xLcSTDeB7A?index=25&list=PL46F0A159EC02DF82&start=100',
+      '//youtube.com/embed/6xLcSTDeB7A?index=25&list=PL46F0A159EC02DF82&start=100',
     ],
   });
   testUrls(newParser(), {
@@ -182,7 +182,7 @@ test('YouTube: playlist urls', () => {
     formats: {
       embed: 'https://www.youtube.com/embed?list=PL46F0A159EC02DF82&listType=playlist',
     },
-    urls: ['https://www.youtube.com/embed?list=PL46F0A159EC02DF82&listType=playlist'],
+    urls: ['//youtube.com/embed?list=PL46F0A159EC02DF82&listType=playlist'],
   });
 });
 


### PR DESCRIPTION
Rather than output URLs of the form `//youtube.com/embed/HRb7B9fPhfA`, this PR instead proposes to output URLs of the form `https://www.youtube.com/embed/HRb7B9fPhfA` to avoid the latency of a HTTP 301 redirect.