### PR TITLE
Adds www to YouTube's long URLs

### DIFF
--- a/lib/provider/youtube.js
+++ b/lib/provider/youtube.js
@@ -129,11 +129,11 @@ YouTube.prototype.createLongUrl = function(vi, params) {
   }
   if (vi.mediaType === this.mediaTypes.PLAYLIST) {
     params.feature = 'share';
-    url += 'https://youtube.com/playlist';
+    url += 'https://www.youtube.com/playlist';
   }
   if (vi.mediaType === this.mediaTypes.VIDEO) {
     params.v = vi.id;
-    url += 'https://youtube.com/watch';
+    url += 'https://www.youtube.com/watch';
   }
   if (vi.mediaType === this.mediaTypes.SHARE) {
     params.ci = vi.id;

--- a/lib/provider/youtube.test.js
+++ b/lib/provider/youtube.test.js
@@ -23,13 +23,8 @@ test('YouTube: regular urls', () => {
       mediaType: 'video',
     },
     formats: {
-<<<<<<< HEAD
-      long: 'https://www.youtube.com/watch?v=HRb7B9fPhfA',
-      embed: '//youtube.com/embed/HRb7B9fPhfA',
-=======
       long: 'https://youtube.com/watch?v=HRb7B9fPhfA',
       embed: 'https://www.youtube.com/embed/HRb7B9fPhfA',
->>>>>>> master
       short: 'https://youtu.be/HRb7B9fPhfA',
       shortImage: 'https://i.ytimg.com/vi/HRb7B9fPhfA/hqdefault.jpg',
       longImage: 'https://img.youtube.com/vi/HRb7B9fPhfA/hqdefault.jpg',

--- a/lib/provider/youtube.test.js
+++ b/lib/provider/youtube.test.js
@@ -23,7 +23,7 @@ test('YouTube: regular urls', () => {
       mediaType: 'video',
     },
     formats: {
-      long: 'https://youtube.com/watch?v=HRb7B9fPhfA',
+      long: 'https://www.youtube.com/watch?v=HRb7B9fPhfA',
       embed: 'https://www.youtube.com/embed/HRb7B9fPhfA',
       short: 'https://youtu.be/HRb7B9fPhfA',
       shortImage: 'https://i.ytimg.com/vi/HRb7B9fPhfA/hqdefault.jpg',
@@ -45,7 +45,7 @@ test('YouTube: regular urls', () => {
       },
     },
     formats: {
-      long: 'https://youtube.com/watch?v=HRb7B9fPhfA#t=30',
+      long: 'https://www.youtube.com/watch?v=HRb7B9fPhfA#t=30',
       embed: 'https://www.youtube.com/embed/HRb7B9fPhfA?start=30',
       short: 'https://youtu.be/HRb7B9fPhfA#t=30',
     },
@@ -87,7 +87,7 @@ test('YouTube: playlist urls', () => {
       },
     },
     formats: {
-      long: 'https://youtube.com/watch?list=PL46F0A159EC02DF82&v=yQaAGmHNn9s#t=100',
+      long: 'https://www.youtube.com/watch?list=PL46F0A159EC02DF82&v=yQaAGmHNn9s#t=100',
       embed: 'https://www.youtube.com/embed/yQaAGmHNn9s?list=PL46F0A159EC02DF82&start=100',
     },
     urls: [
@@ -104,7 +104,7 @@ test('YouTube: playlist urls', () => {
       mediaType: 'video',
     },
     formats: {
-      long: 'https://youtube.com/watch?list=PL46F0A159EC02DF82&v=yQaAGmHNn9s',
+      long: 'https://www.youtube.com/watch?list=PL46F0A159EC02DF82&v=yQaAGmHNn9s',
       embed: 'https://www.youtube.com/embed/yQaAGmHNn9s?list=PL46F0A159EC02DF82',
     },
     urls: [
@@ -123,7 +123,7 @@ test('YouTube: playlist urls', () => {
       },
     },
     formats: {
-      long: 'https://youtube.com/watch?index=25&list=PL46F0A159EC02DF82&v=6xLcSTDeB7A',
+      long: 'https://www.youtube.com/watch?index=25&list=PL46F0A159EC02DF82&v=6xLcSTDeB7A',
       embed: 'https://www.youtube.com/embed/6xLcSTDeB7A?index=25&list=PL46F0A159EC02DF82',
     },
     urls: [
@@ -144,7 +144,7 @@ test('YouTube: playlist urls', () => {
       },
     },
     formats: {
-      long: 'https://youtube.com/watch?index=25&list=PL46F0A159EC02DF82&v=6xLcSTDeB7A#t=100',
+      long: 'https://www.youtube.com/watch?index=25&list=PL46F0A159EC02DF82&v=6xLcSTDeB7A#t=100',
       embed: 'https://www.youtube.com/embed/6xLcSTDeB7A?index=25&list=PL46F0A159EC02DF82&start=100',
     },
     urls: [
@@ -162,7 +162,7 @@ test('YouTube: playlist urls', () => {
       mediaType: 'playlist',
     },
     formats: {
-      long: 'https://youtube.com/playlist?feature=share&list=PL46F0A159EC02DF82',
+      long: 'https://www.youtube.com/playlist?feature=share&list=PL46F0A159EC02DF82',
       embed: 'https://www.youtube.com/embed?list=PL46F0A159EC02DF82&listType=playlist',
     },
     urls: [

--- a/lib/provider/youtube.test.js
+++ b/lib/provider/youtube.test.js
@@ -23,7 +23,7 @@ test('YouTube: regular urls', () => {
       mediaType: 'video',
     },
     formats: {
-      long: 'https://youtube.com/watch?v=HRb7B9fPhfA',
+      long: 'https://www.youtube.com/watch?v=HRb7B9fPhfA',
       embed: '//youtube.com/embed/HRb7B9fPhfA',
       short: 'https://youtu.be/HRb7B9fPhfA',
       shortImage: 'https://i.ytimg.com/vi/HRb7B9fPhfA/hqdefault.jpg',
@@ -45,7 +45,7 @@ test('YouTube: regular urls', () => {
       },
     },
     formats: {
-      long: 'https://youtube.com/watch?v=HRb7B9fPhfA#t=30',
+      long: 'https://www.youtube.com/watch?v=HRb7B9fPhfA#t=30',
       embed: '//youtube.com/embed/HRb7B9fPhfA?start=30',
       short: 'https://youtu.be/HRb7B9fPhfA#t=30',
     },
@@ -87,7 +87,7 @@ test('YouTube: playlist urls', () => {
       },
     },
     formats: {
-      long: 'https://youtube.com/watch?list=PL46F0A159EC02DF82&v=yQaAGmHNn9s#t=100',
+      long: 'https://www.youtube.com/watch?list=PL46F0A159EC02DF82&v=yQaAGmHNn9s#t=100',
       embed: '//youtube.com/embed/yQaAGmHNn9s?list=PL46F0A159EC02DF82&start=100',
     },
     urls: [
@@ -104,7 +104,7 @@ test('YouTube: playlist urls', () => {
       mediaType: 'video',
     },
     formats: {
-      long: 'https://youtube.com/watch?list=PL46F0A159EC02DF82&v=yQaAGmHNn9s',
+      long: 'https://www.youtube.com/watch?list=PL46F0A159EC02DF82&v=yQaAGmHNn9s',
       embed: '//youtube.com/embed/yQaAGmHNn9s?list=PL46F0A159EC02DF82',
     },
     urls: [
@@ -123,7 +123,7 @@ test('YouTube: playlist urls', () => {
       },
     },
     formats: {
-      long: 'https://youtube.com/watch?index=25&list=PL46F0A159EC02DF82&v=6xLcSTDeB7A',
+      long: 'https://www.youtube.com/watch?index=25&list=PL46F0A159EC02DF82&v=6xLcSTDeB7A',
       embed: '//youtube.com/embed/6xLcSTDeB7A?index=25&list=PL46F0A159EC02DF82',
     },
     urls: [
@@ -144,7 +144,7 @@ test('YouTube: playlist urls', () => {
       },
     },
     formats: {
-      long: 'https://youtube.com/watch?index=25&list=PL46F0A159EC02DF82&v=6xLcSTDeB7A#t=100',
+      long: 'https://www.youtube.com/watch?index=25&list=PL46F0A159EC02DF82&v=6xLcSTDeB7A#t=100',
       embed: '//youtube.com/embed/6xLcSTDeB7A?index=25&list=PL46F0A159EC02DF82&start=100',
     },
     urls: [
@@ -162,7 +162,7 @@ test('YouTube: playlist urls', () => {
       mediaType: 'playlist',
     },
     formats: {
-      long: 'https://youtube.com/playlist?feature=share&list=PL46F0A159EC02DF82',
+      long: 'https://www.youtube.com/playlist?feature=share&list=PL46F0A159EC02DF82',
       embed: '//youtube.com/embed?list=PL46F0A159EC02DF82&listType=playlist',
     },
     urls: [
@@ -194,7 +194,7 @@ test('YouTube: feed urls', () => {
       'mediaType': 'video',
     },
     formats: {
-      long: 'https://youtube.com/watch?v=HRb7B9fPhfA',
+      long: 'https://www.youtube.com/watch?v=HRb7B9fPhfA',
       short: 'https://youtu.be/HRb7B9fPhfA',
       embed: '//youtube.com/embed/HRb7B9fPhfA',
     },


### PR DESCRIPTION
To avoid HTTP 301 redirects from youtube.com to www.youtube.com. Replaces https://github.com/Zod-/jsVideoUrlParser/pull/49.