### PR TITLE
add missing TED export

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -10,4 +10,5 @@ require('./provider/youtube');
 require('./provider/soundcloud');
 require('./provider/teachertube');
 require('./provider/tiktok');
+require('./provider/ted');
 module.exports = parser;


### PR DESCRIPTION
### What?
Add `TED` to `index.js`.

### Why?
Because I forget it on [this PR](https://github.com/Zod-/jsVideoUrlParser/pull/67).
