### PR TITLE
Fix template.d.ts incorrect import of urlParser

### DIFF
--- a/lib/provider/template.d.ts
+++ b/lib/provider/template.d.ts
@@ -1,4 +1,4 @@
-import { VideoInfo } from 'urlParser';
+import { VideoInfo } from '../urlParser';
 
 export interface TemplateUrlParameters {
     start?: number;


### PR DESCRIPTION
Currently the version published over at **npm** seems to be broken for TypeScript users with the error: `Cannot find module './provider/template' or its corresponding type declarations.`. I assume this could be fixed by pushing a bumped version.

So I installed the module directly from the repo (via `yarn add https://github.com/Zod-/jsVideoUrlParser`) but that also ended in failure due to a typo / wrong import in `template.d.ts`. This PR fixes that typo.

I'd also suggest perhaps adding another script that runs a quick type-check on the project along with linting to prevent these issues in the future.

Thanks!

