### PR TITLE
#71: remove export for template, since it gets ignored by npm

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -6,7 +6,6 @@ export * from './provider/coub';
 export * from './provider/dailymotion';
 export * from './provider/soundcloud';
 export * from './provider/teachertube';
-export * from './provider/template';
 export * from './provider/twitch';
 export * from './provider/vimeo';
 export * from './provider/wistia';


### PR DESCRIPTION
Fixes #71 for release. The previous PR only took care of the typo in the type definition file, but since this file gets ignored by NPM the package (check `.npmignore`) it was breaking on release.