### PR TITLE
Allow parsing of /showcase URLs.

### DIFF
--- a/lib/provider/vimeo.js
+++ b/lib/provider/vimeo.js
@@ -17,7 +17,7 @@ module.exports = Vimeo;
 
 Vimeo.prototype.parseUrl = function(url) {
   var match = url.match(
-    /(?:\/(?:channels\/[\w]+|(?:(?:album\/\d+|groups\/[\w]+)\/)?videos?))?\/(\d+)/i
+    /(?:\/showcase\/\d+)(?:\/(?:channels\/[\w]+|(?:(?:album\/\d+|groups\/[\w]+)\/)?videos?))?\/(\d+)/i
   );
   return match ? match[1] : undefined;
 };


### PR DESCRIPTION
The current Vimeo parser fails on a URL like `https://vimeo.com/showcase/12345/video/67890` (it should still resolve to a video ID of 67890). This PR ignores the /showcase/* part of the URL.