### PR TITLE
Support for hash on Vimeo URLs

### DIFF
--- a/lib/provider/vimeo.js
+++ b/lib/provider/vimeo.js
@@ -22,14 +22,19 @@ Vimeo.prototype.parseUrl = function(url) {
   return match ? match[1] : undefined;
 };
 
-Vimeo.prototype.parseParameters = function(params) {
-  return this.parseTime(params);
+Vimeo.prototype.parseHash = function(url) {
+  var match = url.match(/\/\d+\/(\w+)$/i);
+  return match ? match[1] : undefined;
 };
 
-Vimeo.prototype.parseTime = function(params) {
+Vimeo.prototype.parseParameters = function(params) {
   if (params.t) {
     params.start = getTime(params.t);
     delete params.t;
+  }
+  if (params.h) {
+    params.hash = params.h;
+    delete params.h;
   }
   return params;
 };
@@ -40,10 +45,14 @@ Vimeo.prototype.parse = function(url, params) {
     params: this.parseParameters(params),
     id: this.parseUrl(url),
   };
+  var hash = this.parseHash(url, params);
+  if (hash) {
+    result.params.hash = hash;
+  }
   return result.id ? result : undefined;
 };
 
-Vimeo.prototype.createUrl = function(baseUrl, vi, params) {
+Vimeo.prototype.createUrl = function(baseUrl, vi, params, type) {
   if (!vi.id || vi.mediaType !== this.mediaTypes.VIDEO) {
     return undefined;
   }
@@ -51,6 +60,15 @@ Vimeo.prototype.createUrl = function(baseUrl, vi, params) {
   var url = baseUrl + vi.id;
   var startTime = params.start;
   delete params.start;
+
+  if (params.hash) {
+    if (type === 'embed') {
+      params.h = params.hash;
+    } else if (type === 'long') {
+      url += '/' + params.hash;
+    }
+    delete params.hash;
+  }
 
   url += combineParams(params);
 
@@ -61,11 +79,11 @@ Vimeo.prototype.createUrl = function(baseUrl, vi, params) {
 };
 
 Vimeo.prototype.createLongUrl = function(vi, params) {
-  return this.createUrl('https://vimeo.com/', vi, params);
+  return this.createUrl('https://vimeo.com/', vi, params, 'long');
 };
 
 Vimeo.prototype.createEmbedUrl = function(vi, params) {
-  return this.createUrl('//player.vimeo.com/video/', vi, params);
+  return this.createUrl('//player.vimeo.com/video/', vi, params, 'embed');
 };
 
 require('../base').bind(new Vimeo());

--- a/lib/provider/vimeo.test.js
+++ b/lib/provider/vimeo.test.js
@@ -12,10 +12,10 @@ function newParser() {
 
 test('Vimeo: undefined', () => {
   expect(newParser().parse('https://vimeo.com')).toBe(undefined);
-  expect(newParser().create({ videoInfo: { provider: 'vimeo' } })).toBe(undefined);
-  expect(newParser().create({ videoInfo: { provider: 'vimeo', mediaType: 'video' } })).toBe(undefined);
-  expect(newParser().create({ videoInfo: { provider: 'vimeo', mediaType: 'video' }, format: 'embed' })).toBe(undefined);
-  expect(newParser().create({ videoInfo: { provider: 'vimeo', mediaType: 'video' }, format: 'image' })).toBe(undefined);
+  expect(newParser().create({videoInfo: {provider: 'vimeo'}})).toBe(undefined);
+  expect(newParser().create({videoInfo: {provider: 'vimeo', mediaType: 'video'}})).toBe(undefined);
+  expect(newParser().create({videoInfo: {provider: 'vimeo', mediaType: 'video'}, format: 'embed'})).toBe(undefined);
+  expect(newParser().create({videoInfo: {provider: 'vimeo', mediaType: 'video'}, format: 'image'})).toBe(undefined);
 });
 
 test('Vimeo: urls', () => {
@@ -92,6 +92,23 @@ test('Vimeo: urls', () => {
     },
     urls: ['https://vimeo.com/36881035#t=3m28s',
       '//player.vimeo.com/video/36881035#t=3m28s',
+    ],
+  });
+  testUrls(newParser(), {
+    videoInfo: {
+      provider: 'vimeo',
+      id: '36881035',
+      mediaType: 'video',
+      params: {
+        hash: 'f9ad567296',
+      },
+    },
+    formats: {
+      long: 'https://vimeo.com/36881035/f9ad567296',
+      embed: '//player.vimeo.com/video/36881035?h=f9ad567296',
+    },
+    urls: ['https://vimeo.com/36881035/f9ad567296',
+      '//player.vimeo.com/video/36881035?h=f9ad567296',
     ],
   });
 });


### PR DESCRIPTION
Some Vimeo URLs include a hash in the URL path (`vimeo.com/{video_id}/{hash}), or as a query string param (`?h={hash}`).

This commit adds support for both formats (for parsing and creating urls).