### PR TITLE
Fix error in type declaration

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,7 +1,5 @@
 /*.js
 /*.json
-/lib/provider/template.js
-/lib/provider/template.d.ts
 .*
 coverage
 *.test.js

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "js-video-url-parser",
-  "version": "0.4.1",
+  "version": "0.4.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
### Description
Typescript compiler couldn't find the `./provider/template` module in `js-video-url-parser/lib/index.d.ts:9:15` due to the template files being ignored by NPM.

### Issue
https://github.com/Zod-/jsVideoUrlParser/issues/71

### Proposed changes:
- Bump project version in `package-lock.json` from `0.4.1` to `0.4.3`
- Remove ignored templates from `.npmignore`